### PR TITLE
Add ActiveRecord generator (otherwise rake db:create db:migrate is failing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,10 @@ module Yomobi
       :secret_access_key => ENV['S3_SECRET']
     config.action_mailer.delivery_method = :ses
 
+    config.generators do |g|
+      g.orm :active_record
+    end
+
     config.test_drive_db_name = ENV['TEST_DRIVE_DB_NAME'] || 'test-drive'
   end
 end


### PR DESCRIPTION
@onaseef I've noticed that running rake tasks which using PostgreSQL database are failing without this
